### PR TITLE
fixed ML.Open on MAC OS X systems

### DIFF
--- a/src/MathLink.jl
+++ b/src/MathLink.jl
@@ -85,8 +85,14 @@ end
   ["C:\\Program Files\\Wolfram Research\\Mathematica\\9.0\\math.exe"
    "C:\\Program Files\\Wolfram Research\\Mathematica\\8.0\\math.exe"]
 
+@osx_only const osxtestpaths =
+ ["/Applications/Mathematica.app/Contents/MacOS/MathKernel"]
+
 function math_path()
   @windows_only for path in wintestpaths
+    isfile(path) && return path
+  end
+  @osx_only for path in osxtestpaths
     isfile(path) && return path
   end
   "math"

--- a/src/low_level.jl
+++ b/src/low_level.jl
@@ -12,7 +12,7 @@ include("consts.jl")
 typealias Env Ptr{Void}
 typealias Link Ptr{Void}
 
-mlib = "ml64i3"
+mlib = @osx ? "/Applications/Mathematica.app/Contents/Frameworks/mathlink.framework/mathlink" : "ml64i3"
 macro mlib(); mlib; end
 
 function Open(path = "math")


### PR DESCRIPTION
- added default location of math kernel
- added default location of mathlink library
